### PR TITLE
fix(#10): ajoute bouton toggle dark/light mode

### DIFF
--- a/lib/features/specimen_selection/presentation/pages/specimen_selection_page.dart
+++ b/lib/features/specimen_selection/presentation/pages/specimen_selection_page.dart
@@ -8,14 +8,25 @@ import 'package:speak_for_me/features/translation_generator/presentation/pages/t
 import 'package:speak_for_me/features/favorites/presentation/pages/favorites_page.dart';
 import 'package:speak_for_me/features/statistics/presentation/pages/statistics_page.dart';
 import 'package:speak_for_me/features/history/presentation/pages/history_page.dart';
+import 'package:speak_for_me/main.dart';
 
 class SpecimenSelectionPage extends StatelessWidget {
   const SpecimenSelectionPage({super.key});
+
+  void _toggleTheme(BuildContext context) {
+    final notifier = ThemeController.of(context);
+    notifier.value = switch (notifier.value) {
+      ThemeMode.light => ThemeMode.dark,
+      ThemeMode.dark => ThemeMode.light,
+      ThemeMode.system => ThemeMode.dark,
+    };
+  }
 
   @override
   Widget build(BuildContext context) {
     final profiles = Profile.getAllProfiles();
     final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return Scaffold(
       body: Container(
@@ -34,6 +45,14 @@ class SpecimenSelectionPage extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
+                    IconButton(
+                      icon: Icon(
+                        isDark ? Icons.light_mode_rounded : Icons.dark_mode_rounded,
+                        color: const Color(0xFF667EEA),
+                      ),
+                      tooltip: isDark ? 'Mode clair' : 'Mode sombre',
+                      onPressed: () => _toggleTheme(context),
+                    ),
                     IconButton(
                       icon: const Icon(Icons.history, color: Color(0xFF667EEA)),
                       onPressed: () => Navigator.push(context,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,20 +24,53 @@ Future<void> main() async {
   runApp(const SpeakForMeApp());
 }
 
-class SpeakForMeApp extends StatelessWidget {
+class ThemeController extends InheritedNotifier<ValueNotifier<ThemeMode>> {
+  const ThemeController({
+    super.key,
+    required ValueNotifier<ThemeMode> notifier,
+    required super.child,
+  }) : super(notifier: notifier);
+
+  static ValueNotifier<ThemeMode> of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<ThemeController>()!
+        .notifier!;
+  }
+}
+
+class SpeakForMeApp extends StatefulWidget {
   const SpeakForMeApp({super.key});
+
+  @override
+  State<SpeakForMeApp> createState() => _SpeakForMeAppState();
+}
+
+class _SpeakForMeAppState extends State<SpeakForMeApp> {
+  final _themeMode = ValueNotifier<ThemeMode>(ThemeMode.system);
 
   static const _seedColor = Color(0xFF667EEA);
 
   @override
+  void dispose() {
+    _themeMode.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Speak for Me',
-      debugShowCheckedModeBanner: false,
-      themeMode: ThemeMode.system,
-      theme: _buildTheme(Brightness.light),
-      darkTheme: _buildTheme(Brightness.dark),
-      home: const SpecimenSelectionPage(),
+    return ThemeController(
+      notifier: _themeMode,
+      child: ValueListenableBuilder<ThemeMode>(
+        valueListenable: _themeMode,
+        builder: (context, mode, _) => MaterialApp(
+          title: 'Speak for Me',
+          debugShowCheckedModeBanner: false,
+          themeMode: mode,
+          theme: _buildTheme(Brightness.light),
+          darkTheme: _buildTheme(Brightness.dark),
+          home: const SpecimenSelectionPage(),
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
## Résumé

- Convertit `SpeakForMeApp` en `StatefulWidget` avec un `ValueNotifier<ThemeMode>`
- Ajoute `ThemeController` (InheritedNotifier) pour exposer le toggle à l'arbre de widgets
- Ajoute un `IconButton` soleil/lune dans `SpecimenSelectionPage` pour basculer entre mode clair et mode sombre

## Problème

La feature #10 utilisait uniquement `ThemeMode.system` — l'utilisateur ne pouvait pas forcer le thème depuis l'app.

## Test plan

- [ ] Lancer l'app et vérifier la présence du bouton soleil/lune en haut à droite de l'écran d'accueil
- [ ] Appuyer sur le bouton : l'app bascule entre mode clair et mode sombre
- [ ] Vérifier que l'icône change (soleil en mode sombre, lune en mode clair)
- [ ] Vérifier que le tooltip s'affiche correctement ("Mode sombre" / "Mode clair")